### PR TITLE
Refactor observer szenarios

### DIFF
--- a/Command.feature
+++ b/Command.feature
@@ -14,7 +14,7 @@ Funktionalität: Kommando
     Szenario: Jede Methode mit dem Attribut "InvokeCommand" darf genau ein Interface als Parameter nehmen
       Wenn ich in jeder Klasse nach einer Methode mit dem Attribut "InvokeCommand" suche
       Dann muss jede Methode genau einen Parameter haben
-      Und muss jeder Parameter ein Interface sein
+      Und jeder Parameter muss ein Interface sein
       
     Szenario: Jedes Kommando-Interface muss eine Implementierung haben
       Wenn ich in jeder Klasse nach einer Methode mit dem Attribut "InvokeCommand" suche
@@ -22,7 +22,6 @@ Funktionalität: Kommando
       
     Szenario: Kommando soll ausgeführt werden, wenn es an Invoker übergeben wird
       Wenn ich in jeder Klasse nach einer Methode mit dem Attribut "InvokeCommand" suche
-	  #Preconditions? (alle von oben?)
       Und ich eine Instanz des Invokers erzeuge
       Und ich eine dynamische Instanz des Kommandos erzeuge
       Und dieses Kommando an den Invoker übergebe

--- a/Command.feature
+++ b/Command.feature
@@ -14,7 +14,7 @@ Funktionalität: Kommando
     Szenario: Jede Methode mit dem Attribut "InvokeCommand" darf genau ein Interface als Parameter nehmen
       Wenn ich in jeder Klasse nach einer Methode mit dem Attribut "InvokeCommand" suche
       Dann muss jede Methode genau einen Parameter haben
-      Und jeder Parameter muss ein Interface sein
+      Und muss jeder Parameter ein Interface sein
       
     Szenario: Jedes Kommando-Interface muss eine Implementierung haben
       Wenn ich in jeder Klasse nach einer Methode mit dem Attribut "InvokeCommand" suche
@@ -22,6 +22,7 @@ Funktionalität: Kommando
       
     Szenario: Kommando soll ausgeführt werden, wenn es an Invoker übergeben wird
       Wenn ich in jeder Klasse nach einer Methode mit dem Attribut "InvokeCommand" suche
+	  #Preconditions? (alle von oben?)
       Und ich eine Instanz des Invokers erzeuge
       Und ich eine dynamische Instanz des Kommandos erzeuge
       Und dieses Kommando an den Invoker übergebe

--- a/Observer.feature
+++ b/Observer.feature
@@ -1,33 +1,52 @@
 #language: de
 #noinspection SpellCheckingInspection
 
-Funktionalität: Observer
+Funktionalität: Beobachter
 
   Grundlage:
-    Gegeben sei eine Liste von Subjekten
+    Gegeben sei eine Liste von Klassen mit dem Attribut "Subject"
     Dann darf diese Liste nicht leer sein
 
-    Szenario: Alle Subjekte sollen eine Methode zum Hinzufügen eines Beobachters bieten
-      Dann sollen alle Subjekte eine Methode zum Hinzufügen bieten
+  Szenario: Alle Subjekte sollen eine Methode zum Hinzufügen eines Beobachters bieten
+    Wenn ich in jeder Klasse nach einer Methode mit dem Attribut "RegisterObserver" suche
+    Dann erwarte ich mir jeweils genau eine Methode
 
-    Szenario: Alle Subjekte sollen eine Methode zum Entfernen eines Beobachters bieten
-      Dann sollen alle Subjekte eine Methode zum Entfernen bieten
+  Szenario: Eine Methode zum Hinzufügen eines Beobachters muss strukturell korrekt sein
+    Wenn ich in jeder Klasse nach einer Methode mit dem Attribut "RegisterObserver" suche
+    Dann erwarte ich mir eine Methode, die mit einem dieser Präfixe beginnt: "add, register, attach, subscribe"
+    Und jede Methode muss genau "1" Parameter haben
+    Und jeder Parameter muss ein Interface sein
 
-    Szenario: Alle Subjekte sollen eine Methode zum Aktualisieren aller Beobachters bieten
-      Dann sollen alle Subjekte eine Methode zum Aktualisieren bieten
+  Szenario: Alle Subjekte sollen eine Methode zum Entfernen eines Beobachters bieten
+    Wenn ich in jeder Klasse nach einer Methode mit dem Attribut "UnregisterObserver" suche
+    Dann erwarte ich mir jeweils genau eine Methode
 
-    Szenario: Beobachter sollen aufgerufen werden, wenn sie registriert sind
-      Gegeben sei ein Beobachter
-      Wenn sich dieser Beobachter registriert
-      Und die Method zum Aktualisieren aufgerufen wird
-      Dann soll der Beobachter aufgerufen werden
+  Szenario: Eine Methode zum Entfernen eines Beobachters muss strukturell korrekt sein
+    Wenn ich in jeder Klasse nach einer Methode mit dem Attribut "RegisterObserver" suche
+    Dann erwarte ich mir eine Methode, die mit einem dieser Präfixe beginnt: "remove, unregister, detach, unsubscribe"
+    Und jede Methode muss genau "1" Parameter haben
+    Und jeder Parameter muss ein Interface sein
 
-    Szenario: Beobachter sollen nicht mehr aufgerufen werden, wenn sie sich vom Subjekt abmelden
-      Gegeben sei ein Beobachter
-      Wenn sich dieser Beobachter registriert
-      Und sich dieser Beobachter wieder abmeldet
-      Und die Method zum Aktualisieren aufgerufen wird
-      Dann soll der Beobachter nicht aufgerufen worden sein
+  Szenario: Alle Subjekte sollen eine Methode zum Aktualisieren der Beobachters bieten
+    Wenn ich in jeder Klasse nach einer Methode mit dem Attribut "NotifyObservers" suche
+    Dann erwarte ich mir jeweils genau eine Methode
 
+  Szenario: Eine Methode zum Aktualisieren der Beobachter muss strukturell korrekt sein
+    Wenn ich in jeder Klasse nach einer Methode mit dem Attribut "RegisterObserver" suche
+    Dann erwarte ich mir eine Methode, die mit einem dieser Präfixe beginnt: "update, notify"
+    Und jede Methode muss genau "0" Parameter haben
 
+  Szenario: Beobachter sollen aufgerufen werden, wenn sie registriert sind
+    Gegeben sei eine Instanz des Subjekts
+    Und eine Instanz des Beobachters
+    Wenn ich diesen Beobachter hinzufügen
+    Und die Methode zum Aktualisieren aufrufe
+    Dann soll der Beobachter "1" Mal aufgerufen werden
 
+  Szenario: Beobachter sollen nicht mehr aufgerufen werden, wenn sie sich vom Subjekt abmelden
+    Gegeben sei eine Instanz des Subjekts
+    Und eine Instanz des Beobachters
+    Wenn ich diesen Beobachter hinzufügen
+    Und ich diesen Beobachter entferne
+    Und die Methode zum Aktualisieren aufrufe
+    Dann soll der Beobachter "0" Mal aufgerufen werden


### PR DESCRIPTION
Schau dir die Szenarien mal durch. Ich bin ohne den Methoden-Attributen auf keinen grünen Zweig gekommen, weil es einfach sau blöd ist, die `register` etc Methoden zu finden, wenns um Überprüfen der Funktionalität geht. 
Da brauchst du dann nämlich alle 3 Methoden gleichzeitig und dann funktioniert das mit dem Reduzieren nicht mehr. 
Ich würds ned schlimm finden, wenn wir 3 Methoden-Attribute einführen, zb:
- RegisterObserver
- UnregisterObserver
- NotifyObservers

Die Namingconvention kann man ja (siehe Szenarien) auch so überprüfen.

PS: Der andere PR (#2) ist ja jetzt auch noch drinnen, wichtig ist also nur der letzte Commit (6f93ac0).
